### PR TITLE
Add build for Scala 2.11 and bump deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,15 +14,15 @@ resolvers += "Clojars" at "http://clojars.org/repo"
 
 resolvers += Resolver.typesafeRepo("releases")
 
-val akkaVersion = "2.3.9"
+val akkaVersion = "2.3.11"
 
 libraryDependencies += "com.aphyr" % "riemann-java-client" % "0.2.9"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-actor" % akkaVersion
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 
-libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2.1" % "test"
+libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,25 +2,29 @@ name := "riemann-scala-client"
 
 organization := "net.benmur"
 
-version := "0.3.2"
+version := "0.3.3-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.6"
+
+crossScalaVersions := Seq("2.10.5", "2.11.6")
 
 scalacOptions ++= List("-deprecation", "-feature", "-unchecked")
 
 resolvers += "Clojars" at "http://clojars.org/repo"
 
-resolvers += "Akka" at "http://repo.akka.io/releases"
+resolvers += Resolver.typesafeRepo("releases")
 
-libraryDependencies += "com.aphyr" % "riemann-java-client" % "0.2.0"
+val akkaVersion = "2.3.9"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.2.3"
+libraryDependencies += "com.aphyr" % "riemann-java-client" % "0.2.9"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M5b" % "test"
+libraryDependencies += "com.typesafe.akka" %% "akka-actor" % akkaVersion
 
-libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.0.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % "2.2.3" % "test"
+libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2.1" % "test"
+
+libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test"
 
 parallelExecution in Test := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/test/scala/net/benmur/riemann/client/EventDSLTest.scala
+++ b/src/test/scala/net/benmur/riemann/client/EventDSLTest.scala
@@ -15,73 +15,73 @@ class EventDSLTest extends FunSuite {
   import EventDSL._
 
   test("provide an EventPart builder function for host") {
-    expectResult(EventPart(host = Some("h"))) {
+    assertResult(EventPart(host = Some("h"))) {
       host("h")
     }
   }
 
   test("provide an EventPart builder function for empty events") {
-    expectResult(EventPart()) {
+    assertResult(EventPart()) {
       oneEvent()
     }
   }
 
   test("provide an EventPart builder function for service") {
-    expectResult(EventPart(service = Some("se"))) {
+    assertResult(EventPart(service = Some("se"))) {
       service("se")
     }
   }
 
   test("provide an EventPart builder function for state") {
-    expectResult(EventPart(state = Some("st"))) {
+    assertResult(EventPart(state = Some("st"))) {
       state("st")
     }
   }
 
   test("provide an EventPart builder function for time") {
-    expectResult(EventPart(time = Some(1234L))) {
+    assertResult(EventPart(time = Some(1234L))) {
       time(1234L)
     }
   }
 
   test("provide an EventPart builder function for description") {
-    expectResult(EventPart(description = Some("d"))) {
+    assertResult(EventPart(description = Some("d"))) {
       description("d")
     }
   }
 
   test("provide an EventPart builder function for tags") {
-    expectResult(EventPart(tags = Array("t1", "t2"))) {
+    assertResult(EventPart(tags = Array("t1", "t2"))) {
       EventDSL.tags("t1", "t2")
     }
   }
 
   test("provide an EventPart builder function for metric (float)") {
-    expectResult(EventPart(metric = Some(1.12f))) {
+    assertResult(EventPart(metric = Some(1.12f))) {
       metric(1.12f)
     }
   }
 
   test("provide an EventPart builder function for metric (double)") {
-    expectResult(EventPart(metric = Some(1.12))) {
+    assertResult(EventPart(metric = Some(1.12))) {
       metric(1.12)
     }
   }
 
   test("provide an EventPart builder function for metric (long)") {
-    expectResult(EventPart(metric = Some(112L))) {
+    assertResult(EventPart(metric = Some(112L))) {
       metric(112L)
     }
   }
 
   test("provide an EventPart builder function for ttl") {
-    expectResult(EventPart(ttl = Some(10))) {
+    assertResult(EventPart(ttl = Some(10))) {
       ttl(10)
     }
   }
 
   test("EventParts combination merges tags") {
-    expectResult(EventPart(tags = Array("tag1", "tag2", "tag3"))) {
+    assertResult(EventPart(tags = Array("tag1", "tag2", "tag3"))) {
       EventDSL.tags("tag1", "tag2") | EventDSL.tags() | EventDSL.tags("tag3") | EventDSL.tags("tag1")
     }
   }
@@ -91,7 +91,7 @@ class EventDSLTest extends FunSuite {
       state = Some("ok"), time = Some(1234L), description = Some("descript"),
       tags = Array("tag1", "tag2"), metric = Some(112L), ttl = Some(10L))
 
-    expectResult(expected) {
+    assertResult(expected) {
       ttl(10) | metric(112) | EventDSL.tags("tag1", "tag2") | description("descript") |
         time(1234L) | state("discarded-state") | state("ok") | service("service-name") |
         host("server")

--- a/src/test/scala/net/benmur/riemann/client/ReliableIOTest.scala
+++ b/src/test/scala/net/benmur/riemann/client/ReliableIOTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.DurationInt
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 import com.aphyr.riemann.Proto
 
@@ -37,7 +37,7 @@ import testingsupport.TestingTransportSupport.timeout
 class ReliableIOTest extends FunSuite
   with testingsupport.ImplicitActorSystem
   with MockFactory
-  with ShouldMatchers {
+  with Matchers {
 
   import ReliableIO._
   import testingsupport.TestingTransportSupport._
@@ -61,8 +61,8 @@ class ReliableIOTest extends FunSuite
 
     val out = oos.toByteArray
     val outRef = protoMsgEvent.toByteArray
-    new DataInputStream(new ByteArrayInputStream(out)).readInt should be === outRef.length
-    out.slice(4, out.length) should be === outRef
+    new DataInputStream(new ByteArrayInputStream(out)).readInt should === (outRef.length)
+    out.slice(4, out.length) should === (outRef)
   }
 
   test("sending a protobuf Msg with Event, with feedback") {
@@ -91,11 +91,11 @@ class ReliableIOTest extends FunSuite
 
     val out = oos.toByteArray
     val outRef = protoMsgEvent.toByteArray
-    new DataInputStream(new ByteArrayInputStream(out)).readInt should be === outRef.length
-    out.slice(4, out.length) should be === outRef
+    new DataInputStream(new ByteArrayInputStream(out)).readInt should === (outRef.length)
+    out.slice(4, out.length) should === (outRef)
 
     val resp = Await.result(respFuture, 1.second)
-    resp should be === true
+    resp should === (true)
   }
 
   test("sending a protobuf Msg with Query, with feedback") {
@@ -124,11 +124,11 @@ class ReliableIOTest extends FunSuite
 
     val out = oos.toByteArray
     val queryData = protoMsgQuery.toByteArray
-    new DataInputStream(new ByteArrayInputStream(out)).readInt should be === queryData.length
-    out.slice(4, out.length) should be === queryData
+    new DataInputStream(new ByteArrayInputStream(out)).readInt should === (queryData.length)
+    out.slice(4, out.length) should === (queryData)
 
     val resp = Await.result(respFuture, 1.second)
-    resp should be === Seq(event, event2)
+    resp should === (Seq(event, event2))
   }
 
   test("reconnect in case of SocketException while reading") {
@@ -161,16 +161,16 @@ class ReliableIOTest extends FunSuite
     val is = new ByteArrayInputStream(out)
     val dis = new DataInputStream(is)
 
-    dis.readInt should be === queryData.length
+    dis.readInt should === (queryData.length)
     val msg1 = Array.ofDim[Byte](queryData.length)
     dis.readFully(msg1)
-    msg1 should be === queryData
+    msg1 should === (queryData)
 
     // 2 messages were written because it crashed during the 1st response read, after writing
-    dis.readInt should be === queryData.length
+    dis.readInt should === (queryData.length)
     val msg2 = Array.ofDim[Byte](queryData.length)
     dis.readFully(msg2)
-    msg2 should be === queryData
+    msg2 should === (queryData)
   }
 
   test("reconnect in case of SocketException while connecting") {
@@ -198,7 +198,7 @@ class ReliableIOTest extends FunSuite
 
     val out = os.toByteArray
     val queryData = protoMsgQuery.toByteArray
-    new DataInputStream(new ByteArrayInputStream(out)).readInt should be === queryData.length
-    out.slice(4, out.length) should be === queryData
+    new DataInputStream(new ByteArrayInputStream(out)).readInt should === (queryData.length)
+    out.slice(4, out.length) should === (queryData)
   }
 }

--- a/src/test/scala/net/benmur/riemann/client/RiemannClientWithDestinationAPITest.scala
+++ b/src/test/scala/net/benmur/riemann/client/RiemannClientWithDestinationAPITest.scala
@@ -4,7 +4,7 @@ import scala.annotation.implicitNotFound
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 import testingsupport.TestingTransportSupport.TestingTransport
 import testingsupport.TestingTransportSupport.TestingTransportConnection
@@ -15,7 +15,7 @@ import testingsupport.TestingTransportSupport.event2
 import testingsupport.TestingTransportSupport.timeout
 
 class RiemannClientWithDestinationAPITest extends FunSuite
-  with ShouldMatchers
+  with Matchers
   with testingsupport.ImplicitActorSystem
   with MockFactory {
 

--- a/src/test/scala/net/benmur/riemann/client/SerializersTest.scala
+++ b/src/test/scala/net/benmur/riemann/client/SerializersTest.scala
@@ -3,7 +3,7 @@ package net.benmur.riemann.client
 import scala.collection.JavaConversions.asJavaIterable
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 import com.aphyr.riemann.Proto
 
@@ -12,7 +12,7 @@ import testingsupport.SerializersFixture.event2
 import testingsupport.SerializersFixture.protobufEvent1
 import testingsupport.SerializersFixture.protobufEvent2
 
-class SerializersTest extends FunSuite with ShouldMatchers {
+class SerializersTest extends FunSuite with Matchers {
   object Serializers extends Serializers
   import Serializers._
   import testingsupport.SerializersFixture._
@@ -20,7 +20,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
   test("out: convert a full EventPart to a protobuf Msg") {
     val expected = Proto.Msg.newBuilder.addEvents(protobufEvent1).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(event1)
     }
   }
@@ -29,7 +29,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart())
     }
   }
@@ -38,7 +38,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setHost("host")).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(host = Some("host")))
     }
   }
@@ -47,7 +47,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setService("service")).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(service = Some("service")))
     }
   }
@@ -56,7 +56,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setState("state")).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(state = Some("state")))
     }
   }
@@ -65,7 +65,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setTime(1234L)).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(time = Some(1234L)))
     }
   }
@@ -74,7 +74,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setDescription("description")).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(description = Some("description")))
     }
   }
@@ -83,7 +83,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.addAllTags(List("tag1"))).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(tags = List("tag1")))
     }
   }
@@ -92,7 +92,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setMetricSint64(1234L)).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(metric = Some(1234L)))
     }
   }
@@ -101,7 +101,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setMetricD(1234.9)).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(metric = Some(1234.9)))
     }
   }
@@ -110,7 +110,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setMetricF(1234.9f)).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(metric = Some(1234.9f)))
     }
   }
@@ -119,7 +119,7 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setTtl(1234L)).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(ttl = Some(1234L)))
     }
   }
@@ -127,19 +127,19 @@ class SerializersTest extends FunSuite with ShouldMatchers {
   test("out: convert an Iterable of full EventParts to a protobuf Msg") {
     val expected = Proto.Msg.newBuilder.addEvents(protobufEvent1).addEvents(protobufEvent2).build
 
-    expectResult(expected) {
+    assertResult(expected) {
       serializeEventPartsToProtoMsg(EventSeq(event1, event2))
     }
   }
 
   test("out: convert a Query to a protobuf Msg") {
-    expectResult(Proto.Msg.newBuilder.setQuery(Proto.Query.newBuilder.setString("true")).build) {
+    assertResult(Proto.Msg.newBuilder.setQuery(Proto.Query.newBuilder.setString("true")).build) {
       serializeQueryToProtoMsg(Query("true"))
     }
   }
 
   test("in: convert a protobuf Msg response with an ok status") {
-    expectResult(Nil) {
+    assertResult(Nil) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).build)
     }
   }
@@ -148,18 +148,18 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val ex = intercept[RemoteError] {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(false).setError("meh").build)
     }
-    ex.message should be === "meh"
+    ex.message should === ("meh")
   }
 
   test("in: convert a failed Query result from a protobuf Msg with events") {
     val ex = intercept[RemoteError] {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(false).setError("meh").addEvents(protobufEvent1).build)
     }
-    ex.message should be === "meh"
+    ex.message should === ("meh")
   }
 
   test("in: convert a successful Query result from a protobuf Msg to multiple EventParts") {
-    expectResult(List(event1)) {
+    assertResult(List(event1)) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(protobufEvent1).build)
     }
   }
@@ -168,81 +168,81 @@ class SerializersTest extends FunSuite with ShouldMatchers {
     val ex = intercept[RemoteError] {
       unserializeProtoMsg(Proto.Msg.newBuilder.addEvents(protobufEvent1).build)
     }
-    ex.message should be === "Response has no status"
+    ex.message should === ("Response has no status")
   }
 
   test("in: convert a protobuf Msg with empty Event to a List(EventPart)") {
-    expectResult(List(EventPart())) {
+    assertResult(List(EventPart())) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only host to a List(EventPart)") {
-    expectResult(List(EventPart(host = Some("host")))) {
+    assertResult(List(EventPart(host = Some("host")))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setHost("host")).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only service to a List(EventPart)") {
-    expectResult(List(EventPart(service = Some("service")))) {
+    assertResult(List(EventPart(service = Some("service")))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setService("service")).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only state to a List(EventPart)") {
-    expectResult(List(EventPart(state = Some("state")))) {
+    assertResult(List(EventPart(state = Some("state")))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setState("state")).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only time to a List(EventPart)") {
-    expectResult(List(EventPart(time = Some(1234L)))) {
+    assertResult(List(EventPart(time = Some(1234L)))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setTime(1234L)).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only description to a List(EventPart)") {
-    expectResult(List(EventPart(description = Some("description")))) {
+    assertResult(List(EventPart(description = Some("description")))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setDescription("description")).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only tags to a List(EventPart)") {
-    expectResult(List(EventPart(tags = List("tag1", "tag2")))) {
+    assertResult(List(EventPart(tags = List("tag1", "tag2")))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.addAllTags(List("tag1", "tag2"))).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only metric (long) to a List(EventPart)") {
-    expectResult(List(EventPart(metric = Some(1234L)))) {
+    assertResult(List(EventPart(metric = Some(1234L)))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setMetricSint64(1234L)).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only metric (float) to a List(EventPart)") {
-    expectResult(List(EventPart(metric = Some(1234.0f)))) {
+    assertResult(List(EventPart(metric = Some(1234.0f)))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setMetricF(1234.0f)).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only metric (double) to a List(EventPart)") {
-    expectResult(List(EventPart(metric = Some(1234.1: Double)))) {
+    assertResult(List(EventPart(metric = Some(1234.1: Double)))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setMetricD(1234.1: Double)).build)
     }
   }
 
   test("in: convert a protobuf Msg with Event with only ttl to a List(EventPart)") {
-    expectResult(List(EventPart(ttl = Some(1234L)))) {
+    assertResult(List(EventPart(ttl = Some(1234L)))) {
       unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setTtl(1234L)).build)
     }


### PR DESCRIPTION
I've updated the build to include support for both Scala 2.10 and 2.11. I've also bumped some library deps and updated the source code to resolve deprecation warnings.

Perhaps the biggest change is the upgrade from Akka 2.2 to 2.3, however I've been running with this configuration in production for about a month now without trouble.