### PR TITLE
Release version 0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
   - 2.10.5
-  - 2.11.6
+  - 2.11.7

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scala client library for sending events to [Riemann](http://riemann.io/), featur
 ## Usage
 
 ### Build System
-In build.sbt (scala 2.11.6):
+In build.sbt (scala 2.11.7):
 ```
 libraryDependencies += "net.benmur" %% "riemann-scala-client" % "0.3.3-SNAPSHOT"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "riemann-scala-client"
 
 organization := "net.benmur"
 
-version := "0.3.3-SNAPSHOT"
+version := "0.3.3"
 
 scalaVersion := "2.11.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "net.benmur"
 
 version := "0.3.3-SNAPSHOT"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 scalacOptions ++= List("-deprecation", "-feature", "-unchecked")
 


### PR DESCRIPTION
We've been using this version of the library in several apps in production without trouble since it was created. I think it's safe to publish a 0.3.3 release. Note, I didn't update the version numbers in the README.md because I wasn't sure how to.