### PR TITLE
Java compat metric codec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.3.4"
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 scalacOptions ++= List("-deprecation", "-feature", "-unchecked")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "riemann-scala-client"
 
 organization := "net.benmur"
 
-version := "0.3.4"
+version := "0.4.0-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/scala/net/benmur/riemann/client/Serializers.scala
+++ b/src/main/scala/net/benmur/riemann/client/Serializers.scala
@@ -31,8 +31,8 @@ trait Serializers {
     e.description foreach (b.setDescription(_))
     e.tags foreach (b.addTags(_))
     e.metric foreach (_ match {
-      case value: Long => b.setMetricSint64(value)
-      case value: Double => b.setMetricD(value)
+      case value: Long => b.setMetricSint64(value); b.setMetricF(value)
+      case value: Double => b.setMetricD(value); b.setMetricF(value.toFloat)
       case value: Float => b.setMetricF(value)
       case v => System.err.println("Warning: don't know what to do with value " + v)
     })
@@ -53,9 +53,9 @@ trait Serializers {
   private def extractMetric(e: Proto.Event) =
     if (e.hasMetricD)
       Some(e.getMetricD)
-    else if (e.hasMetricF)
-      Some(e.getMetricF)
     else if (e.hasMetricSint64)
       Some(e.getMetricSint64)
+    else if (e.hasMetricF)
+      Some(e.getMetricF)
     else None
 }

--- a/src/test/scala/net/benmur/riemann/client/SerializersTest.scala
+++ b/src/test/scala/net/benmur/riemann/client/SerializersTest.scala
@@ -88,25 +88,25 @@ class SerializersTest extends FunSuite with Matchers {
     }
   }
 
-  test("out: convert an EventPart with only metric (long) to a protobuf Msg") {
+  test("out: convert an EventPart setting only metric (long) to a protobuf Msg") {
     val expected = Proto.Msg.newBuilder.addEvents(
-      Proto.Event.newBuilder.setMetricSint64(1234L)).build
+      Proto.Event.newBuilder.setMetricSint64(1234L).setMetricF(1234f)).build
 
     assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(metric = Some(1234L)))
     }
   }
 
-  test("out: convert an EventPart with only metric (double) to a protobuf Msg") {
+  test("out: convert an EventPart setting only metric (double) to a protobuf Msg") {
     val expected = Proto.Msg.newBuilder.addEvents(
-      Proto.Event.newBuilder.setMetricD(1234.9)).build
+      Proto.Event.newBuilder.setMetricD(1234.9).setMetricF(1234.9f)).build
 
     assertResult(expected) {
       serializeEventPartToProtoMsg(EventPart(metric = Some(1234.9)))
     }
   }
 
-  test("out: convert an EventPart with only metric (float) to a protobuf Msg") {
+  test("out: convert an EventPart setting only metric (float) to a protobuf Msg") {
     val expected = Proto.Msg.newBuilder.addEvents(
       Proto.Event.newBuilder.setMetricF(1234.9f)).build
 
@@ -220,24 +220,33 @@ class SerializersTest extends FunSuite with Matchers {
     }
   }
 
-  test("in: convert a protobuf Msg with Event with only metric (long) to a List(EventPart)") {
-    assertResult(List(EventPart(metric = Some(1234L)))) {
-      unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
-        Proto.Event.newBuilder.setMetricSint64(1234L)).build)
+  test("in: convert a protobuf Msg with Event with metrics (long) and (float) to a List(EventPart)") {
+    val expected = List(EventPart(metric = Some(1234L)))
+    val actual = unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
+        Proto.Event.newBuilder.setMetricSint64(1234L).setMetricF(1234)).build)
+    assertResult(expected)(actual)
+    assertResult(expected.map(_.metric.map(_.getClass))) {
+      actual.map(_.metric.map(_.getClass))
     }
   }
 
   test("in: convert a protobuf Msg with Event with only metric (float) to a List(EventPart)") {
-    assertResult(List(EventPart(metric = Some(1234.0f)))) {
-      unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
+    val expected = List(EventPart(metric = Some(1234.0f)))
+    val actual = unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
         Proto.Event.newBuilder.setMetricF(1234.0f)).build)
+    assertResult(expected)(actual)
+    assertResult(expected.map(_.metric.map(_.getClass))) {
+      actual.map(_.metric.map(_.getClass))
     }
   }
 
-  test("in: convert a protobuf Msg with Event with only metric (double) to a List(EventPart)") {
-    assertResult(List(EventPart(metric = Some(1234.1: Double)))) {
-      unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
-        Proto.Event.newBuilder.setMetricD(1234.1: Double)).build)
+  test("in: convert a protobuf Msg with Event with metrics (double) and (float) to a List(EventPart)") {
+    val expected = List(EventPart(metric = Some(1234.1)))
+    val actual = unserializeProtoMsg(Proto.Msg.newBuilder.setOk(true).addEvents(
+        Proto.Event.newBuilder.setMetricD(1234.1).setMetricF(1234.1f)).build)
+    assertResult(expected)(actual)
+    assertResult(expected.map(_.metric.map(_.getClass))) {
+      actual.map(_.metric.map(_.getClass))
     }
   }
 

--- a/src/test/scala/net/benmur/riemann/client/testingsupport/SerializersFixture.scala
+++ b/src/test/scala/net/benmur/riemann/client/testingsupport/SerializersFixture.scala
@@ -23,6 +23,7 @@ object SerializersFixture {
     .addAllTags(Seq("tag1", "tag2"))
     .setTtl(10)
     .setMetricSint64(112)
+    .setMetricF(112)
     .setDescription("descript")
 
   val protobufEvent2 = Proto.Event.newBuilder
@@ -33,5 +34,6 @@ object SerializersFixture {
     .addAllTags(Seq("tag3"))
     .setTtl(100)
     .setMetricSint64(1120)
+    .setMetricF(1120)
     .setDescription("descript2")
 }


### PR DESCRIPTION
Modify metric serialization/deserialization to conform to the official Java and Ruby clients' conventions.

Bump version to 0.4.0-SNAPSHOT.

Addresses #14